### PR TITLE
chore(deps): upgrade eslint-plugin peerDep for eslint-config

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "^7.2.0",
     "@babel/eslint-parser": "^7.2.0",
     "@babel/eslint-plugin": "^7.2.0",
-    "@poool/eslint-plugin": "^1.4.0",
+    "@poool/eslint-plugin": "^2.0.0",
     "eslint": "^7.2.0 || ^8.0.0",
     "eslint-config-standard": "^15.0.0 || ^16.0.0 || ^17.0.0",
     "eslint-plugin-import": "^2.20.2",


### PR DESCRIPTION
This will remove the warning we get when doing `yarn install` in any repo importing `@poool/eslint-config`.

Plus, running `npm install` with default config will no longer fail because of this peer dependency.